### PR TITLE
fix(ci): repair release pipeline and add EOL watch (endoflife.date)

### DIFF
--- a/.github/config/.releaserc.json
+++ b/.github/config/.releaserc.json
@@ -1,0 +1,35 @@
+{
+  "branches": [
+    "main"
+  ],
+  "tagFormat": "v${version}",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -2,18 +2,18 @@
 name: Manual - Release
 on:
   workflow_dispatch:
-permissions:
-  contents: read
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 jobs:
   release:
     name: Release
     runs-on: ubuntu-24.04
+    if: ${{ github.ref == 'refs/heads/main' }}
+    timeout-minutes: 30
     permissions:
       contents: write
-      id-token: write
-      issues: write
-      pull-requests: write
-    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -23,23 +23,40 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: "lts/*"
-      - name: Copy rules
+      - name: Install semantic-release
         run: |
-          cp .github/config/.releaserc.json .
-      - name: Install dependencies
+          # Local install: semantic-release resolves plugins from
+          # ./node_modules; isolated global packages are not resolvable.
+          npm install --no-save --no-package-lock \
+            semantic-release@24 \
+            @semantic-release/changelog@6 \
+            @semantic-release/commit-analyzer@13 \
+            @semantic-release/release-notes-generator@14 \
+            @semantic-release/git@10 \
+            conventional-changelog-conventionalcommits@8
+      - name: Compute next version, changelog and tag
+        run: npx --no-install semantic-release --extends ./.github/config/.releaserc.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Tags pushed with GITHUB_TOKEN do not trigger the tag-push workflow
+      # (GitHub blocks workflow chaining), so goreleaser runs here when
+      # semantic-release created a release tag on HEAD.
+      - name: Detect released tag
+        id: tag
         run: |
-          npm install --location=global semantic-release@23.0.0 \
-            @semantic-release/changelog@6.0.3 \
-            @semantic-release/commit-analyzer@11.1.0 \
-            @semantic-release/exec@6.0.3 \
-            @semantic-release/git@10.0.1 \
-            @semantic-release/gitlab@13.0.2 \
-            @semantic-release/npm@11.0.2 \
-            @semantic-release/release-notes-generator@12.1.0 \
-            @commitlint/cli@18.4.4 \
-            @commitlint/config-conventional@18.4.4 \
-            conventional-changelog-conventionalcommits@7.0.2
-      - name: Release
-        run: npx semantic-release
+          echo "tag=$(git describe --exact-match --tags HEAD 2>/dev/null || true)" \
+            >> "$GITHUB_OUTPUT"
+      - name: Set up Go
+        if: steps.tag.outputs.tag != ''
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: Run GoReleaser
+        if: steps.tag.outputs.tag != ''
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/eol-check.yaml
+++ b/.github/workflows/eol-check.yaml
@@ -1,0 +1,59 @@
+---
+name: EOL Watch
+permissions: {}
+on:
+  schedule:
+    # Mondays 06:17 UTC; odd minute avoids the top-of-hour load spike
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+jobs:
+  eol-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Check product lifecycles
+        id: eol
+        run: ./scripts/eol-check.sh
+      - name: Open or update tracking issue
+        if: steps.eol.outputs.has_findings == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh label create eol-watch --force \
+            --color D93F0B --description "Product approaching or past end-of-life"
+          existing="$(gh issue list --label eol-watch --state open \
+            --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file eol-report.md
+          else
+            gh issue create --label eol-watch --body-file eol-report.md \
+              --title "EOL watch: action needed on pinned products"
+          fi
+      - name: Close tracking issue when clean
+        if: steps.eol.outputs.has_findings == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          existing="$(gh issue list --label eol-watch --state open \
+            --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" \
+              --comment "All tracked products are maintained again. ✅"
+          fi
+      - name: Fail on end-of-life products
+        if: steps.eol.outputs.worst == 'eol'
+        run: |
+          echo "::error::At least one pinned product is end-of-life. See the job summary."
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ vendor/
 Godeps/
 bin/
 dist/
+
+### Node (semantic-release tooling in CI) ###
+node_modules/
+package.json
+package-lock.json

--- a/scripts/eol-check.sh
+++ b/scripts/eol-check.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Checks the products pinned in this repository against the endoflife.date
+# API v1 (https://endoflife.date/docs/api/v1/) and reports their lifecycle
+# status. Versions are parsed from the repository's sources of truth, never
+# hardcoded:
+#   - go     <- .go-version
+#   - alpine <- Dockerfile (final stage base image)
+#   - ubuntu <- pinned runner labels in .github/workflows/
+#
+# Output: a markdown table on stdout (and in $GITHUB_STEP_SUMMARY when set),
+# a markdown report at eol-report.md, and step outputs (has_findings, worst)
+# in $GITHUB_OUTPUT when set. Always exits 0; the workflow decides whether to
+# fail based on the outputs.
+#
+# Environment:
+#   EOL_WARN_DAYS  days before EOL to start warning (default: 90)
+#   EOL_API_BASE   API base URL override, mainly for tests
+set -euo pipefail
+
+API_BASE="${EOL_API_BASE:-https://endoflife.date/api/v1/products}"
+WARN_DAYS="${EOL_WARN_DAYS:-90}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPORT_FILE="${EOL_REPORT_FILE:-eol-report.md}"
+
+rows=""
+worst="ok" # escalates: ok -> warn -> eol
+
+# discover prints one "product cycle source" line per pinned product.
+discover() {
+  local go_version alpine_tag ubuntu_pin
+  go_version="$(tr -d '[:space:]' <"$ROOT/.go-version")"
+  printf 'go %s .go-version\n' "$(printf '%s' "$go_version" | cut -d. -f1,2)"
+
+  alpine_tag="$(sed -n 's/^FROM alpine:\([0-9][0-9.]*\).*/\1/p' "$ROOT/Dockerfile" | head -1)"
+  if [ -n "$alpine_tag" ]; then
+    printf 'alpine %s Dockerfile\n' "$(printf '%s' "$alpine_tag" | cut -d. -f1,2)"
+  fi
+
+  ubuntu_pin="$(grep -rhoE 'ubuntu-[0-9]+\.[0-9]+' "$ROOT/.github/workflows" | sort -u | head -1 | sed 's/ubuntu-//')"
+  if [ -n "$ubuntu_pin" ]; then
+    printf 'ubuntu %s workflows\n' "$ubuntu_pin"
+  fi
+}
+
+escalate() {
+  case "$1:$worst" in
+    eol:*) worst="eol" ;;
+    warn:ok) worst="warn" ;;
+  esac
+}
+
+# check queries the API for one product cycle and appends a table row.
+check() {
+  local product="$1" cycle="$2" source="$3"
+  local json fields is_eol is_maintained eol_from latest days status
+
+  if ! json="$(curl -fsSL --retry 3 --max-time 30 "$API_BASE/$product/releases/$cycle")"; then
+    rows+="| $product | $cycle | ⚠️ lookup failed | - | - | $source |"$'\n'
+    escalate "warn"
+    return
+  fi
+
+  fields="$(jq -r '.result | [
+    (.isEol | tostring),
+    (.isMaintained | tostring),
+    (.eolFrom // "-"),
+    (.latest.name // "-"),
+    (if .eolFrom then
+       ((((.eolFrom | strptime("%Y-%m-%d") | mktime) - now) / 86400) | floor | tostring)
+     else "-" end)
+  ] | join(" ")' <<<"$json")"
+  read -r is_eol is_maintained eol_from latest days <<<"$fields"
+
+  if [ "$is_eol" = "true" ]; then
+    status="❌ end-of-life"
+    escalate "eol"
+  elif [ "$days" != "-" ] && [ "$days" -le "$WARN_DAYS" ]; then
+    status="⚠️ EOL in ${days}d"
+    escalate "warn"
+  elif [ "$is_maintained" != "true" ]; then
+    status="⚠️ unmaintained"
+    escalate "warn"
+  else
+    status="✅ maintained"
+  fi
+
+  rows+="| $product | $cycle | $status | $eol_from | $latest | $source |"$'\n'
+}
+
+main() {
+  while read -r product cycle source; do
+    check "$product" "$cycle" "$source"
+  done < <(discover)
+
+  local report
+  report="## EOL watch — pinned products
+
+Data: [endoflife.date](https://endoflife.date) API v1 · warn window: ${WARN_DAYS} days
+
+| Product | Pinned cycle | Status | EOL date | Latest release | Pinned in |
+| ------- | ------------ | ------ | -------- | -------------- | --------- |
+${rows}"
+
+  printf '%s\n' "$report"
+  printf '%s\n' "$report" >"$REPORT_FILE"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "$report" >>"$GITHUB_STEP_SUMMARY"
+  fi
+
+  local has_findings="false"
+  if [ "$worst" != "ok" ]; then
+    has_findings="true"
+  fi
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      printf 'has_findings=%s\n' "$has_findings"
+      printf 'worst=%s\n' "$worst"
+    } >>"$GITHUB_OUTPUT"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Dois assuntos de CI/CD, em commits separados.

## 1. Conserto da release manual ([run que falhou](https://github.com/lpsm-dev/gtoc/actions/runs/29533880129/job/87740415429))

Causa imediata: o workflow copiava `.github/config/.releaserc.json`, **que nunca foi commitado** (não existe em nenhum ponto do histórico). Ao investigar, encontrei mais dois defeitos latentes que quebrariam a release mesmo com o arquivo presente:

1. **Install global de plugins**: o semantic-release não resolve plugins instalados como pacotes globais isolados do npm (validei localmente: `Cannot find module '@semantic-release/commit-analyzer'`). Migrado para o install local documentado - dry-run local confirma todos os plugins carregando.
2. **Encadeamento de workflows bloqueado**: a tag criada pelo semantic-release usa `GITHUB_TOKEN`, e push de tag com esse token **não dispara** o workflow de goreleaser (prevenção de recursão do GitHub). O goreleaser agora roda no mesmo job, condicionado à existência de tag nova no HEAD.

Também: `.releaserc.json` criado (preset conventionalcommits, changelog + git; a GitHub Release fica com o goreleaser, evitando duplicidade), removidos os installs mortos de gitlab/npm/commitlint, versões modernas pinadas (semantic-release 24), permissions mínimas (`contents: write`), timeout e concurrency. `node_modules` entrou no `.gitignore` para o check de dirty-tree do goreleaser não falhar.

## 2. Pipeline de EOL (pedido novo)

Workflow semanal (`EOL Watch`, segunda 06:17 UTC + `workflow_dispatch`) que acompanha o ciclo de vida dos produtos pinados no repo via [endoflife.date API v1](https://endoflife.date/docs/api/v1/):

| Produto | Fonte da verdade |
|---|---|
| go | `.go-version` |
| alpine | `Dockerfile` (imagem final) |
| ubuntu | pins `ubuntu-XX.YY` nos workflows |

Nenhuma versão hardcoded: o script parseia dos arquivos. Lógica (`scripts/eol-check.sh`, shellcheck-clean, só curl+jq):

- Consulta `/products/{p}/releases/{cycle}` e avalia `isEol`/`eolFrom`/`isMaintained` (trata `eolFrom: null`, caso do Go)
- Tabela markdown no job summary
- **Issue única idempotente** com label `eol-watch`: cria/atualiza quando há alerta (EOL ou < 90 dias), fecha quando limpa
- Run só fica vermelho quando algo **já está** EOL

Hardening conforme guidance oficial de Actions: `permissions: {}` no topo com escopo por job, checkout sem credenciais persistidas, timeout, concurrency, cron fora do pico. **Decisão consciente**: script próprio em vez da action de terceiros `sindrel/endoflife-github-action` - baixo uso + releases não-imutáveis = risco de supply chain apontado na própria comunidade do endoflife.date.

Estado atual (rodado localmente): go 1.26 ✅ · alpine 3.24 ✅ (EOL 2028-06) · ubuntu 24.04 ✅ (EOL 2029-05).

Co-Authored-By: Claude <noreply@anthropic.com>