### PR TITLE
docs(agents): add working-method section from claude code best practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,29 @@ golangci-lint run ./...   # or: task go:lint
   behavior, update or add the test describing the new behavior first, then make
   it pass.
 
+## Working method
+
+Distilled from [Claude Code's best practices](https://code.claude.com/docs/en/best-practices);
+they apply to any coding agent working here:
+
+- **Close the loop with a runnable check.** Every change ships with a
+  verification you can execute (test, build, lint, running the binary);
+  iterate until it passes and show the evidence — the command and its output —
+  instead of asserting success.
+- **Explore, plan, then code.** For multi-file or unfamiliar changes, read the
+  relevant code and state a short plan before editing. Skip the ceremony when
+  the diff fits in one sentence.
+- **Fix root causes.** Never suppress an error, skip a failing test, or tweak
+  an assertion to go green; find out why it fails first.
+- **Keep context lean.** Delegate wide codebase exploration to subagents or
+  subtasks that return summaries; scope investigations narrowly instead of
+  reading files indiscriminately.
+- **Review in a fresh context.** Before treating work as done, run a separate
+  review pass (subagent or new session) of the diff against the requirements.
+  Report correctness gaps only — no speculative hardening, no style nits.
+- **Prefer CLIs for external services.** Use `gh` for anything GitHub
+  (issues, PRs, workflow runs) instead of raw API calls.
+
 ## Commits and releases
 
 - **Conventional Commits**: `type(scope): description`, lowercase, imperative,


### PR DESCRIPTION
Condensa no [AGENTS.md](AGENTS.md) o subconjunto **voltado a agentes** das [best practices oficiais do Claude Code](https://code.claude.com/docs/pt/best-practices), como seção `Working method`:

- Fechar o loop com verificação executável + mostrar evidência (comando e saída), não afirmar sucesso
- Explore → plan → code (pulando cerimônia quando o diff cabe numa frase)
- Corrigir causa raiz, nunca suprimir erro ou maquiar teste
- Contexto enxuto: exploração ampla via subagents que retornam resumos
- Revisão adversarial em contexto limpo antes de dar por pronto, reportando só lacunas de corretude (sem over-engineering)
- CLI-first para serviços externos (`gh`)

## Julgamento de abordagem (por que não uma rule)

1. A maior parte do guia é orientação para o **operador humano** (`/clear`, plan mode, permissões, sessões paralelas, checkpoints) - não é instrução de agente e inflaria o arquivo. A própria página manda podar: *"para cada linha, pergunte se removê-la causaria erros; se não, corte"*.
2. Uma `.claude/rules/` fragmentaria a convenção estabelecida no #35: **AGENTS.md é a fonte única cross-tool** e CLAUDE.md é só `@AGENTS.md`. Rules servem para instruções escopadas por path, o que não é o caso.
3. AGENTS.md segue enxuto: 111 linhas (bem abaixo do teto prático de ~200 do arquivo sempre-carregado).

Co-Authored-By: Claude <noreply@anthropic.com>