### PR TITLE
ci: harden workflows per actionlint and zizmor audit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    "helpers:pinGitHubActionDigests",
     ":disableDependencyDashboard"
   ],
   "postUpdateOptions": [

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -15,16 +15,21 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Persisted credentials are required here: semantic-release pushes
+      # the changelog commit and the release tag back to main.
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # zizmor: ignore[artipacked] v7
         with:
           fetch-depth: 0
+      # Node cache does not feed the published artifact: goreleaser builds
+      # from git-tracked Go sources only.
       - name: Setup node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # zizmor: ignore[cache-poisoning] v7
         with:
           node-version: "lts/*"
+      # Throwaway release tooling, majors pinned; not part of the artifact.
       - name: Install semantic-release
-        run: |
+        run: |  # zizmor: ignore[adhoc-packages]
           # Local install: semantic-release resolves plugins from
           # ./node_modules; isolated global packages are not resolvable.
           npm install --no-save --no-package-lock \
@@ -48,12 +53,14 @@ jobs:
             >> "$GITHUB_OUTPUT"
       - name: Set up Go
         if: steps.tag.outputs.tag != ''
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version-file: go.mod
+          # No cache restore in the artifact-publishing path (cache poisoning)
+          cache: false
       - name: Run GoReleaser
         if: steps.tag.outputs.tag != ''
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version-file: go.mod
       - name: Build
@@ -29,17 +31,29 @@ jobs:
       - name: Coverage summary
         run: go tool cover -func=coverage.out | tail -1
       - name: Lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a  # v9
         with:
           version: latest
   vulncheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version-file: go.mod
       - name: Run govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+  lint-workflows:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
+      - name: Audit workflows with zizmor
+        run: pipx run zizmor==1.27.0 --offline --no-progress .github/workflows/

--- a/.github/workflows/eol-check.yaml
+++ b/.github/workflows/eol-check.yaml
@@ -18,7 +18,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
           persist-credentials: false
       - name: Check product lifecycles

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -12,15 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version-file: go.mod
+          # No cache restore in the artifact-publishing path (cache poisoning)
+          cache: false
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Validação completa das actions, como pedido, com três ferramentas - e correção de tudo que apareceu.

## Resultado da auditoria

| Ferramenta | Antes | Depois |
|---|---|---|
| actionlint 1.7.12 (sintaxe, expressões, inputs, shellcheck) | 0 issues | 0 issues |
| yamllint `--strict` | OK | OK |
| **zizmor 1.27.0** (auditoria de segurança) | **21 findings (16 high)** | **0 findings** |

## O que foi corrigido

1. **SHA-pinning das 13 refs de actions** (`unpinned-uses`, high): tags como `@v7` são mutáveis - quem compromete o repo da action move a tag. Agora tudo pinado em commit SHA imutável com a tag como comentário. SHAs resolvidos via `git ls-remote` e mantidos automaticamente pelo Renovate (`helpers:pinGitHubActionDigests` adicionado; updates de digest caem no automerge existente).
2. **`persist-credentials: false`** em todo checkout que não faz push (`artipacked`): CI (2 jobs), goreleaser, eol-check.
3. **Cache do setup-go desabilitado nos caminhos que publicam artefato** (`cache-poisoning`): goreleaser.yaml e _release.yaml.
4. **Riscos residuais deliberados suprimidos inline com justificativa** no _release.yaml: o checkout da release precisa de credenciais (semantic-release pusha changelog + tag) e o cache de node / install ad-hoc não alimentam o binário Go publicado.
5. **Novo job `lint-workflows` no CI**: roda zizmor pinado (`--offline`) em todo push/PR, para a auditoria continuar verde permanentemente em vez de ser um check pontual.

Refs de validação empírica: CI passou hoje várias vezes com essas mesmas versões de actions (a checagem via API REST ficou inconclusiva pela degradação atual do GitHub, os SHAs vieram do protocolo git, que está saudável).

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Pinned GitHub Actions to specific revisions to improve workflow reliability and supply-chain security.
  - Added automated auditing for workflow security issues.
- **Maintenance**
  - Updated dependency automation to support pinning GitHub Action revisions.
  - Preserved existing CI, release, vulnerability checks, and end-of-line validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->