### PR TITLE
feat(generator): hierarchical dotted numbering for the toc (1, 1.1, 1.1.1)

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -63,10 +63,10 @@ func TestGenerateCommandUpdatesFile(t *testing.T) {
 	}
 
 	expectedEntries := []string{
-		"1. [First Heading](#first-heading)",
-		"   1. [First Sub-heading](#first-sub-heading)",
-		"2. [Second Heading](#second-heading)",
-		"3. [Third Heading](#third-heading)",
+		"1\\. [First Heading](#first-heading)",
+		"&nbsp;&nbsp;&nbsp;1\\.1. [First Sub-heading](#first-sub-heading)",
+		"2\\. [Second Heading](#second-heading)",
+		"3\\. [Third Heading](#third-heading)",
 	}
 	for _, entry := range expectedEntries {
 		if !strings.Contains(content, entry) {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -66,25 +66,42 @@ func (g *Generator) Generate() (string, error) {
 	return sb.String(), nil
 }
 
-// renderEntries renders the TOC as a numbered (ordered) list. Numbering is
-// per level and restarts whenever a deeper level is re-entered, so nested
-// sub-sections read 1., 2., ... under their parent. Ordered-list items are
-// indented three spaces per level so GitHub renders the nesting correctly.
+// renderEntries renders the TOC as a hierarchical dotted outline: every
+// heading carries its full path number (# -> 1, ## -> 1.1, ### -> 1.1.1),
+// reflecting the heading depth. GitHub markdown has no native "1.1." list
+// marker, so entries are emitted as escaped literal text - the leading dot is
+// backslash-escaped so the line is not parsed as an ordered list - indented
+// with &nbsp; per level and separated with <br> so each entry keeps its own
+// line in a rendered README.
 func renderEntries(headings []*Heading, minLevel int) string {
 	var sb strings.Builder
-	counters := make(map[int]int)
+	var counters []int
 	for _, heading := range headings {
 		rel := heading.Level - minLevel
-		for deeper := range counters {
-			if deeper > rel {
-				delete(counters, deeper)
+		if rel < len(counters) {
+			counters = counters[:rel+1]
+		} else {
+			for len(counters) <= rel {
+				counters = append(counters, 0)
 			}
 		}
 		counters[rel]++
-		indent := strings.Repeat("   ", rel)
-		sb.WriteString(fmt.Sprintf("%s%d. [%s](#%s)\n", indent, counters[rel], heading.Text, heading.Anchor))
+
+		marker := strings.Replace(dottedNumber(counters)+".", ".", `\.`, 1)
+		indent := strings.Repeat("&nbsp;", 3*rel)
+		sb.WriteString(fmt.Sprintf("%s%s [%s](#%s)<br>\n", indent, marker, heading.Text, heading.Anchor))
 	}
 	return sb.String()
+}
+
+// dottedNumber joins the per-level counters into a dotted path such as
+// "1", "1.2", or "1.2.1".
+func dottedNumber(counters []int) string {
+	parts := make([]string, len(counters))
+	for i, c := range counters {
+		parts[i] = fmt.Sprintf("%d", c)
+	}
+	return strings.Join(parts, ".")
 }
 
 // minHeadingLevel returns the smallest heading level present in headings, or

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -50,10 +50,10 @@ Content for the third heading.
 	}
 
 	expected := tocStartMarker + "\n\n" +
-		"1. [First Heading](#first-heading)\n" +
-		"   1. [First Sub-heading](#first-sub-heading)\n" +
-		"2. [Second Heading](#second-heading)\n" +
-		"3. [Third Heading](#third-heading)\n" +
+		"1\\. [First Heading](#first-heading)<br>\n" +
+		"&nbsp;&nbsp;&nbsp;1\\.1. [First Sub-heading](#first-sub-heading)<br>\n" +
+		"2\\. [Second Heading](#second-heading)<br>\n" +
+		"3\\. [Third Heading](#third-heading)<br>\n" +
 		"\n" + backToTopLink + "\n" +
 		"\n" + tocEndMarker
 
@@ -104,8 +104,8 @@ Second setup section.
 	}
 
 	expectedEntries := []string{
-		"1. [Setup](#setup)\n",
-		"2. [Setup](#setup-1)\n",
+		"1\\. [Setup](#setup)<br>\n",
+		"2\\. [Setup](#setup-1)<br>\n",
 	}
 	for _, entry := range expectedEntries {
 		if !strings.Contains(toc, entry) {
@@ -290,16 +290,16 @@ func TestGenerateIndentNormalization(t *testing.T) {
 	}
 
 	expectedEntries := []string{
-		"1. [Section One](#section-one)\n",
-		"   1. [Subsection](#subsection)\n",
-		"2. [Section Two](#section-two)\n",
+		"1\\. [Section One](#section-one)<br>\n",
+		"&nbsp;&nbsp;&nbsp;1\\.1. [Subsection](#subsection)<br>\n",
+		"2\\. [Section Two](#section-two)<br>\n",
 	}
 	for _, entry := range expectedEntries {
 		if !strings.Contains(toc, entry) {
 			t.Errorf("TOC should contain entry %q when document starts at level 2, got: %s", entry, toc)
 		}
 	}
-	if strings.Contains(toc, "      1. [Subsection]") {
+	if strings.Contains(toc, "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1\\.1. [Subsection]") {
 		t.Error("indentation should be normalized relative to the document's minimum heading level")
 	}
 }


### PR DESCRIPTION
O #39 mergeou o commit da numeração **flat** (por nível) antes do meu commit dotted registrar - ficou órfão. Este PR traz a numeração **hierárquica pontilhada**: # → 1, ## → 1.1, ### → 1.1.1, refletindo a profundidade. Números literais escapados + &nbsp; + &lt;br&gt; (markdown não tem 1.1 nativo), verificado contra a API /markdown do GitHub. Testes verdes.