### PR TITLE
feat(generate): --number-headings numbers headings in the document body

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -13,11 +13,12 @@ import (
 )
 
 var (
-	filePath     string
-	depth        int
-	excludePaths string
-	dryRun       bool
-	prettyOutput bool
+	filePath       string
+	depth          int
+	excludePaths   string
+	dryRun         bool
+	prettyOutput   bool
+	numberHeadings bool
 )
 
 // generateCmd handles TOC generation for markdown files.
@@ -58,6 +59,11 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 
 	logger.Info("Generating table of contents", "file", absFilePath)
 	gen := generator.NewGenerator(absFilePath, depth, excludeList)
+
+	if numberHeadings {
+		return runNumberHeadings(gen, absFilePath, path)
+	}
+
 	toc, err := gen.Generate()
 	if err != nil {
 		return fmt.Errorf("failed to generate table of contents: %w", err)
@@ -68,6 +74,33 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	}
 
 	return writeTOC(gen, path, toc)
+}
+
+// runNumberHeadings numbers the document's headings in place and refreshes the
+// TOC to link to them, previewing (--dry-run) or writing the result.
+func runNumberHeadings(gen *generator.Generator, absFilePath, path string) error {
+	content, err := gen.GenerateNumberedFile()
+	if err != nil {
+		return fmt.Errorf("failed to number headings: %w", err)
+	}
+
+	if dryRun {
+		fmt.Println("Dry run mode. The document would be updated to:")
+		fmt.Println("\n" + content)
+		return nil
+	}
+
+	mode := os.FileMode(0644)
+	if info, statErr := os.Stat(absFilePath); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+	if err := os.WriteFile(absFilePath, []byte(content), mode); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	logger.Info("File updated successfully", "path", path)
+	fmt.Printf("Successfully numbered headings and updated %s\n", path)
+	return nil
 }
 
 // resolveFilePath returns the target file path from the positional argument
@@ -186,4 +219,5 @@ func init() {
 	generateCmd.Flags().StringVar(&excludePaths, "exclude", "", "Comma-separated heading texts to exclude from the TOC (case-insensitive substring match)")
 	generateCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview changes without writing")
 	generateCmd.Flags().BoolVar(&prettyOutput, "pretty", false, "Render output with formatting and show full file in dry-run mode")
+	generateCmd.Flags().BoolVar(&numberHeadings, "number-headings", false, "Number the document's headings in place (# -> 1., ## -> 1.1., ...) and link the TOC to them")
 }

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -104,6 +104,104 @@ func dottedNumber(counters []int) string {
 	return strings.Join(parts, ".")
 }
 
+// existingNumberPrefix matches a leading outline number ("1. ", "1.2. ", ...)
+// so re-numbering headings is idempotent.
+var existingNumberPrefix = regexp.MustCompile(`^\d+(\.\d+)*\.\s+`)
+
+// headingLine records where a heading sits in the document and its clean text
+// (with any existing outline number stripped).
+type headingLine struct {
+	index int
+	level int
+	text  string
+}
+
+// GenerateNumberedFile rewrites the document so every heading carries its
+// hierarchical outline number (# -> "1.", ## -> "1.1.", ### -> "1.1.1.") and
+// returns the full updated file content, including a refreshed TOC that links
+// to the numbered headings. Numbering is idempotent: an existing number on a
+// heading is stripped and recomputed.
+func (g *Generator) GenerateNumberedFile() (string, error) {
+	raw, err := os.ReadFile(g.targetFile)
+	if err != nil {
+		return "", err
+	}
+	lines := strings.Split(string(raw), "\n")
+
+	found := g.collectHeadingLines(lines)
+	minLevel := 1
+	for i, h := range found {
+		if i == 0 || h.level < minLevel {
+			minLevel = h.level
+		}
+	}
+
+	anchorCounts := map[string]int{}
+	var counters []int
+	headings := make([]*Heading, 0, len(found))
+	for _, h := range found {
+		rel := h.level - minLevel
+		if rel < len(counters) {
+			counters = counters[:rel+1]
+		} else {
+			for len(counters) <= rel {
+				counters = append(counters, 0)
+			}
+		}
+		counters[rel]++
+
+		numberedText := dottedNumber(counters) + ". " + h.text
+		anchor := uniqueAnchor(createAnchor(numberedText), anchorCounts)
+		lines[h.index] = strings.Repeat("#", h.level) + " " + numberedText
+		headings = append(headings, &Heading{Level: h.level, Text: numberedText, Anchor: anchor})
+	}
+
+	numbered := strings.Join(lines, "\n")
+	return g.GetFileWithUpdatedTOC(numbered, buildNumberedTOC(headings, minLevel)), nil
+}
+
+// collectHeadingLines returns every heading line eligible for numbering,
+// skipping fenced code blocks and existing TOC blocks and stripping any
+// existing outline number so re-runs stay stable.
+func (g *Generator) collectHeadingLines(lines []string) []headingLine {
+	var out []headingLine
+	filter := &lineFilter{}
+	for i, line := range lines {
+		if filter.skip(line) {
+			continue
+		}
+		matches := headingPattern.FindStringSubmatch(line)
+		if len(matches) <= 2 {
+			continue
+		}
+		level := len(matches[1])
+		if g.maxDepth > 0 && level > g.maxDepth {
+			continue
+		}
+		text := existingNumberPrefix.ReplaceAllString(strings.TrimSpace(matches[2]), "")
+		if g.isExcluded(text) {
+			continue
+		}
+		out = append(out, headingLine{index: i, level: level, text: text})
+	}
+	return out
+}
+
+// buildNumberedTOC lists already-numbered headings. Because the number is part
+// of each heading (and thus the link text), entries are plain links indented
+// with &nbsp; per level and broken with <br> - no escaping is needed.
+func buildNumberedTOC(headings []*Heading, minLevel int) string {
+	var sb strings.Builder
+	sb.WriteString(tocStartMarker + "\n\n")
+	for _, h := range headings {
+		indent := strings.Repeat("&nbsp;", 3*(h.Level-minLevel))
+		sb.WriteString(fmt.Sprintf("%s[%s](#%s)<br>\n", indent, h.Text, h.Anchor))
+	}
+	sb.WriteString("\n" + backToTopLink + "\n")
+	sb.WriteString("\n" + tocEndMarker)
+	return sb.String()
+}
+
 // minHeadingLevel returns the smallest heading level present in headings, or
 // 1 when there are no headings. This is used to normalize indentation so a
 // document that starts at ## renders its top-level entries with no indent.

--- a/internal/generator/numbering_test.go
+++ b/internal/generator/numbering_test.go
@@ -1,0 +1,77 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeNumberingFile writes content to a temp markdown file and returns its path.
+func writeNumberingFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "doc.md")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	return path
+}
+
+func TestGenerateNumberedFile(t *testing.T) {
+	content := "# First\n\n## Sub A\n\n## Sub B\n\n# Second\n\n## Sub C\n"
+	path := writeNumberingFile(t, content)
+
+	got, err := NewGenerator(path, 0, nil).GenerateNumberedFile()
+	if err != nil {
+		t.Fatalf("GenerateNumberedFile failed: %v", err)
+	}
+
+	wantHeadings := []string{
+		"# 1. First",
+		"## 1.1. Sub A",
+		"## 1.2. Sub B",
+		"# 2. Second",
+		"## 2.1. Sub C",
+	}
+	for _, h := range wantHeadings {
+		if !strings.Contains(got, h+"\n") {
+			t.Errorf("body should contain numbered heading %q, got:\n%s", h, got)
+		}
+	}
+
+	wantTOC := []string{
+		"[1. First](#1-first)<br>",
+		"&nbsp;&nbsp;&nbsp;[1.1. Sub A](#11-sub-a)<br>",
+		"[2. Second](#2-second)<br>",
+		"&nbsp;&nbsp;&nbsp;[2.1. Sub C](#21-sub-c)<br>",
+	}
+	for _, entry := range wantTOC {
+		if !strings.Contains(got, entry) {
+			t.Errorf("TOC should link to numbered heading %q, got:\n%s", entry, got)
+		}
+	}
+}
+
+func TestGenerateNumberedFileIsIdempotent(t *testing.T) {
+	path := writeNumberingFile(t, "# First\n\n## Sub A\n\n# Second\n")
+
+	gen := NewGenerator(path, 0, nil)
+	first, err := gen.GenerateNumberedFile()
+	if err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(first), 0644); err != nil {
+		t.Fatalf("failed to write first result: %v", err)
+	}
+
+	second, err := gen.GenerateNumberedFile()
+	if err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+	if first != second {
+		t.Errorf("numbering should be idempotent:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	if strings.Contains(second, "1. 1. First") || strings.Contains(second, "# 1. 1.") {
+		t.Error("re-numbering must strip the existing number instead of stacking a new one")
+	}
+}


### PR DESCRIPTION
Adiciona `gtoc generate --number-headings`, que numera as **próprias headings** do markdown (não só o TOC): `# -> 1.`, `## -> 1.1.`, `### -> 1.1.1.`, e o TOC linca pra elas. Idempotente (re-rodar não empilha número). Verificado contra a API /markdown do GitHub (headings viram `<h1>1. …` com anchors que batem). Testes novos incluídos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mode to automatically number Markdown headings hierarchically.
  * Refreshes the table of contents and links to match the numbered headings.
  * Supports previewing changes without modifying the file.
  * Preserves existing file permissions when saving updates.
* **Bug Fixes**
  * Re-running numbering no longer duplicates existing heading numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->